### PR TITLE
Solving bug of missing labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,6 @@ __pycache__/
 .pytest_cache
 *.DS_Store
 check_data/
-models/
+/models/
 *.ipynb_checkpoints
 *.db

--- a/src/analytics/metrics/functions.py
+++ b/src/analytics/metrics/functions.py
@@ -1,6 +1,6 @@
 from sklearn.metrics import multilabel_confusion_matrix
 import pandas as pd
-from typing import Dict, Union
+from typing import Dict, Union, List
 
 
 def format_feature_metrics(
@@ -70,7 +70,7 @@ def format_evaluation_metrics_multiple(
 
 
 def confusion_for_multiclass(
-    test_set: pd.DataFrame, prediction_set: pd.DataFrame
+    test_set: pd.DataFrame, prediction_set: pd.DataFrame, labels: List[int]
 ) -> Dict[str, Dict[str, int]]:
     """
     Gets 2 datasets based on multiclass classification and calculates
@@ -89,7 +89,7 @@ def confusion_for_multiclass(
     mult_dict : Dict
 
     """
-    cm = multilabel_confusion_matrix(test_set, prediction_set)
+    cm = multilabel_confusion_matrix(test_set, prediction_set, labels=labels)
     mult_dict = {}
     class_key = 0
     for i in cm:

--- a/src/analytics/metrics/pipelines.py
+++ b/src/analytics/metrics/pipelines.py
@@ -3,7 +3,7 @@ import numpy as np
 from sklearn import metrics
 from sklearn.metrics import confusion_matrix
 from src.analytics.metrics.functions import *
-from typing import Dict, Union, Any
+from typing import Dict, Union, Any, List
 from src.schemas.performanceMetric import (
     BinaryClassificationMetricsPipelineResult,
     MultiClassificationMetricsPipelineResult,
@@ -64,7 +64,7 @@ def create_feature_metrics_pipeline(
 
 
 def create_binary_classification_evaluation_metrics_pipeline(
-    test_set: pd.Series, prediction_set: pd.Series
+    test_set: pd.Series, prediction_set: pd.Series, labels: List[int]
 ) -> BinaryClassificationMetricsPipelineResult:
 
     """
@@ -101,7 +101,7 @@ def create_binary_classification_evaluation_metrics_pipeline(
     precision = metrics.precision_score(test_set, prediction_set)
     recall = metrics.recall_score(test_set, prediction_set)
     f1 = recall = metrics.f1_score(test_set, prediction_set)
-    tn, fp, fn, tp = confusion_matrix(test_set, prediction_set).ravel()
+    tn, fp, fn, tp = confusion_matrix(test_set, prediction_set, labels=labels).ravel()
 
     return BinaryClassificationMetricsPipelineResult(
         **format_evaluation_metrics_binary(
@@ -111,7 +111,7 @@ def create_binary_classification_evaluation_metrics_pipeline(
 
 
 def create_multiple_classification_evaluation_metrics_pipeline(
-    test_set: pd.Series, prediction_set: pd.Series
+    test_set: pd.Series, prediction_set: pd.Series, labels: List[int]
 ) -> MultiClassificationMetricsPipelineResult:
     """
     Multiclass classification evaluation metrics
@@ -181,7 +181,7 @@ def create_multiple_classification_evaluation_metrics_pipeline(
     macro_f1 = metrics.f1_score(test_set, prediction_set, average="macro")
     weighted_f1 = metrics.f1_score(test_set, prediction_set, average="weighted")
     f1_statistics = {"micro": micro_f1, "macro": macro_f1, "weighted": weighted_f1}
-    conf_matrix = confusion_for_multiclass(test_set, prediction_set)
+    conf_matrix = confusion_for_multiclass(test_set, prediction_set, labels)
 
     return MultiClassificationMetricsPipelineResult(
         **format_evaluation_metrics_multiple(

--- a/src/analytics/tests/test_pipelines.py
+++ b/src/analytics/tests/test_pipelines.py
@@ -91,9 +91,20 @@ class TestNodes:
             create_binary_classification_evaluation_metrics_pipeline(
                 test_classification_df["y_testing_binary"],
                 test_classification_df["y_prediction_binary"],
+                labels=[0,1]
             )
         )
 
+        binary_metrics_edge_case = dict(
+            create_binary_classification_evaluation_metrics_pipeline(
+                test_classification_df["y_testing_binary"].tail(1),
+                test_classification_df["y_prediction_binary"].tail(1),
+                labels=[0,1]
+            )
+        )
+
+        
+        assert binary_metrics_edge_case["true_positive"] == 1
         assert binary_metrics["accuracy"] == 0.6
         assert binary_metrics["precision"] == 0.6
         assert binary_metrics["recall"] == 0.6
@@ -107,8 +118,26 @@ class TestNodes:
         multi_metrics = create_multiple_classification_evaluation_metrics_pipeline(
             test_classification_df["y_testing_multi"],
             test_classification_df["y_prediction_multi"],
+            labels=[0,1,2]
         )
+
+        multi_metrics_edge_case = create_multiple_classification_evaluation_metrics_pipeline(
+            test_classification_df["y_testing_multi"].tail(1),
+            test_classification_df["y_prediction_multi"].tail(1),
+            labels=[0,1,2]
+        )        
+
         assert multi_metrics.accuracy == 0.6
+
+        TestCase().assertDictEqual(
+            {
+                "true_negative": 0,
+                "false_positive": 0,
+                "false_negative": 0,
+                "true_positive": 1,
+            },
+            multi_metrics_edge_case.confusion_matrix["class1"].dict(),
+        )
 
         TestCase().assertDictEqual(
             {"micro": 0.6, "macro": 0.6444444444444445, "weighted": 0.64},

--- a/src/cron_tasks/monitoring_metrics.py
+++ b/src/cron_tasks/monitoring_metrics.py
@@ -82,11 +82,13 @@ async def run_calculate_performance_metrics_pipeline(
         )
         return
 
+    labels = list(model.labels.values())
+
     logger.info(f"Calculating performance metrics for model {model.id}")
     if model.type == ModelType.binary:
         binary_classification_metrics_report = (
             create_binary_classification_evaluation_metrics_pipeline(
-                actual_df, processed_df[model.prediction]
+                actual_df, processed_df[model.prediction], labels
             )
         )
 
@@ -101,7 +103,7 @@ async def run_calculate_performance_metrics_pipeline(
     elif model.type == ModelType.multi_class:
         multiclass_classification_metrics_report = (
             create_multiple_classification_evaluation_metrics_pipeline(
-                actual_df, processed_df[model.prediction]
+                actual_df, processed_df[model.prediction], labels
             )
         )
 

--- a/src/schemas/model.py
+++ b/src/schemas/model.py
@@ -26,7 +26,7 @@ class ModelBase(BaseModel):
 
     # TODO do we need this?
     features: Dict[str, FeatureTypes]
-    labels: Optional[Dict[str, int]]
+    labels: Dict[str, int]
 
     prediction: str
     probability: str


### PR DESCRIPTION
With this PR we are adding the labels as a parameter in evaluation pipelines. Also I added an edge case unit test per pipeline. This solves the issue but there are some open questions and pending work:

- @sinnec can you please connect this with the pipeline by feeding the possible labels, as we discussed. Don't forget that we are asking for the values of client's input.
- @momegas we observed along with @sinnec that the labels are optional in models.py under schema folder. This should be mandatory. Also there is a question here, what will happen if the client insert the labels in wrong way? Maybe it is better in our next iteration to find the labels by our own and don't asking them by the client at all. It is pretty easy as we just seeking for the unique values of the target column of training set. 